### PR TITLE
Setup Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+name: release-please
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: terraform-module
+          default-branch: main


### PR DESCRIPTION
This PR adds a `release-please` workflow to this repository, with a configuration for terraform-module.
This workflow will automatically create a PR to bump the version of the module when a new tag is pushed to the repository.

[Release Please](https://github.com/googleapis/release-please) automates CHANGELOG generation, the creation of GitHub releases, and version bumps for your projects.
It does so by parsing your git history, looking for Conventional Commit messages, and creating release PRs.

You can find more information on notion: [How to configure Release Please](https://www.notion.so/m33/How-to-configure-Release-Please-9f2c511fe22d4fd29c66cebe41b57a1f).

🤖 This PR has automatically been opened by Padok Enabler App. Simply close it if you don't want to setup ReleasePlease.
